### PR TITLE
Changes ESNext modules format to CommonJS. NodeJS does not support ES6 Import syntax

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "CommonJS",
     "target": "ES5",
     "jsx": "react",
     "moduleResolution": "Node",


### PR DESCRIPTION
Fixed module error. Changes ESNext modules format to CommonJS. NodeJS does not support ES6 Import syntax