### PR TITLE
Extend Node.js requirement to include v17 and v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aboutbits/react-material-icons",
-  "version": "1.1.3",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aboutbits/react-material-icons",
-      "version": "1.1.3",
+      "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^4.7.4"
       },
       "engines": {
-        "node": "^16",
+        "node": ">=16 <19",
         "npm": "^8"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aboutbits/react-material-icons",
-  "version": "1.1.3",
+  "version": "1.2.3",
   "description": "Material design icon components for React",
   "main": "dist/",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/",
   "engines": {
     "npm": "^8",
-    "node": "^16"
+    "node": ">=16 <19"
   },
   "scripts": {
     "build": "tsc",
@@ -20,11 +20,7 @@
     "version": "npm run test && npm run lint && git add -A src",
     "postversion": "git push && git push --tags"
   },
-  "keywords": [
-    "material design",
-    "icons",
-    "react"
-  ],
+  "keywords": ["material design", "icons", "react"],
   "private": false,
   "author": "AboutBits",
   "license": "MIT",
@@ -32,10 +28,7 @@
     "type": "git",
     "url": "git+https://github.com/aboutbits/react-material-icons"
   },
-  "files": [
-    "readme.md",
-    "dist/**/*"
-  ],
+  "files": ["readme.md", "dist/**/*"],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
There is nothing from preventing this package to be used with v17 and v18. Increasing the version range allows newer projects to use this package too.